### PR TITLE
	modified:   hydrodataset/camels.py

### DIFF
--- a/hydrodataset/camels.py
+++ b/hydrodataset/camels.py
@@ -658,6 +658,10 @@ class Camels(HydroDataset):
                     f_dict[field] = ref.tolist()
                 elif is_numeric_dtype(data_temp[field]):
                     out_temp[:, k] = data_temp[field].values
+                else:
+                    value, ref = pd.factorize(data_temp[field], sort=True)
+                    out_temp[:, k] = value
+                    f_dict[field] = ref.tolist()
                 k = k + 1
             out_lst.append(out_temp)
         out = np.concatenate(out_lst, 1)


### PR DESCRIPTION
data_temp[field]存在空值时is_string_dtype(data_temp[field])和都为is_numeric_dtype(data_temp[field])，导致geol_2nd_class全部为nan，增加else，空值也可以正常处理